### PR TITLE
Correção para o release automático

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,6 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v1
         with:
           node-version: 16
@@ -104,7 +107,7 @@ jobs:
           key: dist-${{ github.run_id }}-${{ github.run_number }}
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: '${{ github.event.commits[0].author.name }}'
           GIT_AUTHOR_EMAIL: '${{ github.event.commits[0].author.email }}'


### PR DESCRIPTION
O release automático com o Github Actions não funciona devido a um problema de permissão.

Esta PR corrige o problema adicionando o secret `SEMANTIC_RELEASE_PAT` com um token com as permissões necessárias.